### PR TITLE
Build new image with latest amazon/aws-cli:2.13.4

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,53 @@
+name: Build & push image workflow
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
+
+    workflow_dispatch:
+        inputs:
+            ref:
+                description: Reference to build image from. `master` will push the `latest` tag.
+                type: string
+                required: false
+                default: master
+env:
+    REGISTRY: ghcr.io     # Using GH Packages for hosting public images
+    IMAGE_NAME: ${{ github.repository }}
+    LATEST: ${{ inputs == null && github.ref_name == 'master' || inputs.ref == 'master' }}
+
+jobs:
+    build-push-image:
+        name: Build & push image
+        runs-on: eks-runner
+        timeout-minutes: 10
+        steps:
+            - name: Checkout ${{ github.repository }}
+              uses: actions/checkout@v3
+
+            - name: Log in to the Container registry
+              uses: docker/login-action@v2
+              with:
+                registry: ${{ env.REGISTRY }}
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+      
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v4
+              with:
+                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                tags: |
+                    type=sha,enable=true,priority=100,prefix=,suffix=_${{ github.run_number }},format=short
+                    type=raw,value=latest,enable=${{env.LATEST}}
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v3.3.0
+              with:
+                context: .
+                push: true
+                tags: ${{ steps.meta.outputs.tags }}
+                labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://aws.amazon.com/blogs/developer/aws-cli-v2-docker-image/
 # https://hub.docker.com/r/amazon/aws-cli
-FROM amazon/aws-cli:2.4.23
+FROM amazon/aws-cli:2.13.4
 
 WORKDIR /
 ADD ./ /

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: 'red'
 runs:
   using: docker
-  image: Dockerfile
+  image: ghcr.io/pipedrive/aws-s3-github-action
 inputs:
   command:
     description: "The command that will be performed. More info: https://docs.aws.amazon.com/cli/latest/reference/s3/#available-commands"


### PR DESCRIPTION
- Changing the action use a pre-built image instead of building a new image on every execution
- Upgrading aws-cli to 2.13.4
- Adding a new workflow for building a new image on changes